### PR TITLE
openHAB Rules file tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "onLanguage:php",
         "onLanguage:json",
         "onLanguage:javascript",
-        "onLanguage:typescript"
+        "onLanguage:typescript",
+        "onLanguage:openhab"
     ],
     "main": "./out/extension",
     "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { Provider } from "./provider";
 import { JsonProvider, PhpProvider, TypescriptProvider } from "./providers";
 import { IBaseProvider } from "./providers/base";
+import { RuleProvider } from "./providers/openhab/rule";
 
 function goToDefinition(range: vscode.Range) {
     const editor: vscode.TextEditor = vscode.window.activeTextEditor;
@@ -23,6 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
         new PhpProvider(),
         new TypescriptProvider(),
         new JsonProvider(),
+        new RuleProvider(),
     ] as Array<IBaseProvider<any>>);
 
     vscode.window.registerTreeDataProvider("tree-outline", provider);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 export { JsonProvider } from "./json";
 export { PhpProvider } from "./php";
 export { TypescriptProvider } from "./typescript";
+export { RuleProvider } from "./openhab/rule";
 export { IBaseProvider } from "./base";

--- a/src/providers/openhab/rule.ts
+++ b/src/providers/openhab/rule.ts
@@ -1,0 +1,132 @@
+import * as json from "jsonc-parser";
+import * as vscode from "vscode";
+import { Provider } from "./../../provider";
+import * as token from "./../../tokens";
+import { IBaseProvider } from "./../base";
+import { IRuleTree, RuleParser } from "./ruleParser";
+
+export class RuleProvider implements IBaseProvider<vscode.TreeItem> {
+    private tree: any;
+    private parser: RuleParser;
+    private text: string;
+    private editor: vscode.TextEditor;
+
+    public constructor() {
+        this.parser = new RuleParser();
+    }
+    public hasSupport(langId: string) {
+        return langId.toLowerCase() === "openhab" &&
+            vscode.window.activeTextEditor.document.fileName.endsWith("rules");
+    }
+
+    public refresh(event?: vscode.TextDocumentChangeEvent): void {
+        // refresh
+    }
+
+    public getChildren(element?: vscode.TreeItem): Thenable<vscode.TreeItem[]> {
+        const text = vscode.window.activeTextEditor.document.getText();
+
+        return this.parser.parseSource(text).then((parsed: IRuleTree) => {
+            this.tree = {
+                imports: [],
+                variables: [],
+                rules: [],
+            };
+
+            for (const imp of parsed.imports) {
+                this.tree.imports.push({
+                    name: imp,
+                    position: this.parser.getPosition(imp),
+                } as token.ImportToken);
+            }
+
+            for (const variable of parsed.variables) {
+                this.tree.variables.push({
+                    name: variable,
+                    position: this.parser.getPosition(variable),
+                });
+            }
+
+            for (const rule of parsed.rules) {
+                this.tree.rules.push({
+                    name: rule,
+                    position: this.parser.getPosition(rule),
+                });
+            }
+
+            const items: vscode.TreeItem[] = [];
+            const tree = this.tree;
+            if (element === undefined) {
+                if (tree.imports && tree.imports.length) {
+                    items.push(new vscode.TreeItem(`Imports`, vscode.TreeItemCollapsibleState.Collapsed));
+                }
+
+                if (tree.variables && tree.variables.length) {
+                    items.push(new vscode.TreeItem(`Variables`, vscode.TreeItemCollapsibleState.Collapsed));
+                }
+
+                if (tree.rules && tree.rules.length) {
+                    items.push(new vscode.TreeItem(
+                        `Rules`,
+                        tree.nodes === undefined && tree.rules !== undefined ?
+                            vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+                    ));
+                }
+            } else {
+                if (element.label === "Imports") {
+                    for (const imp of tree.imports) {
+                        const t = new vscode.TreeItem(
+                            `${imp.name}`,
+                            vscode.TreeItemCollapsibleState.None,
+                        );
+                        t.command = {
+                            arguments: [imp.position],
+                            command: "extension.treeview.goto",
+                            title: "",
+                        };
+                        items.push(t);
+                    }
+                }
+
+                if (element.label === "Variables") {
+                    for (const variable of tree.variables) {
+                        const t = new vscode.TreeItem(
+                            `${variable.name}`,
+                            vscode.TreeItemCollapsibleState.None,
+                        );
+                        t.command = {
+                            arguments: [variable.position],
+                            command: "extension.treeview.goto",
+                            title: "",
+                        };
+                        items.push(t);
+                    }
+                }
+
+                if (element.label === "Rules" && tree.rules !== undefined) {
+                    for (const rule of tree.rules) {
+                        const t = new vscode.TreeItem(
+                            `${rule.name}`,
+                            vscode.TreeItemCollapsibleState.None,
+                        );
+                        t.command = {
+                            arguments: [rule.position],
+                            command: "extension.treeview.goto",
+                            title: "",
+                        };
+                        items.push(Provider.getIcon(
+                            t,
+                            `method`,
+                        ));
+                    }
+                }
+            }
+
+            return Promise.resolve(items);
+        });
+    }
+
+    public getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+}

--- a/src/providers/openhab/ruleParser.ts
+++ b/src/providers/openhab/ruleParser.ts
@@ -1,0 +1,53 @@
+import * as vscode from "vscode";
+import { ImportToken } from "../base";
+
+export class RuleParser {
+    private text: string;
+
+    public parseSource(text: string): Thenable<IRuleTree> {
+        this.text = text;
+        // Remove comments
+        text = text.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "$1");
+        const lines = text.split("\n");
+        const imports = lines
+            .filter((line) => line.trim().startsWith("import"))
+            .map((line) => line.replace(/import/, "").trim()) || [];
+
+        const rules = lines
+            .filter((line) => line.trim().startsWith("rule"))
+            .map((line) => line.replace(/rule/, "").trim()) || [];
+
+        // Remove lambdas
+        text = text.replace(/(\[)([\s\S]*?)(\s])/gm, "$1");
+        const lastImport = imports[imports.length - 1] || "";
+        const vars = text.slice(text.search(lastImport) + lastImport.length, text.search(rules[0]) || text.length);
+        const variables = vars
+            .split("\n")
+            .filter((line) => /val|var/.test(line.trim()))
+            .map((line) => line.split("=")[0].replace(/val |var /, "").trim()) || [];
+
+        return new Promise((resolve) => {
+            resolve({ imports, variables, rules });
+        });
+    }
+
+    public getPosition(text: string): vscode.Range {
+        const query = (q) => q.includes(text);
+        const lines = this.text.split("\n");
+        const line = lines.find(query);
+        const lineIndex = lines.findIndex(query);
+
+        return new vscode.Range(
+            new vscode.Position(lineIndex, line.indexOf(text)),
+            new vscode.Position(lineIndex, line.indexOf(text) + text.length),
+        );
+    }
+}
+
+export interface IRuleTree {
+    variables?: string[];
+
+    imports?: string[];
+
+    rules?: any[];
+}


### PR DESCRIPTION
Hey @DaGhostman!

Thanks for this wonderful extension.
I'm an author of [openhab-vscode](https://github.com/openhab/openhab-vscode) extension. 
[openHAB](https://github.com/openhab) is a home automation software which uses its own DSL to create automation rules. E.g. when motion was detected in the kitchen, turn on the light. Stuff like that ;-)

I thought of writing a tree view of openHAB rules myself, but since you've done so much work yourself, I decided to extend your plugin with some openHAB-related logic, if you don't mind :-)

Here's a screenshot with the preview:
![tree](https://user-images.githubusercontent.com/2270505/34447020-460a3762-ece0-11e7-987d-2727ca6a1a24.gif)

And here's the packaged extension:
[vs-treeview-0.1.0.vsix.zip](https://github.com/DaGhostman/vscode-tree-view/files/1594275/vs-treeview-0.1.0.vsix.zip)

All the best,
Kuba