### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Change Log
 
+_[BC]_ Stands for *B*reaking *C*hange
+## [1.0.0]
+
+### Added
+
+- [ALL] - Support for globally(file-level) defined variables in separate
+ expandable section (collapsed by default)
+
+### Changed
+
+- [ALL] - Renamed `Provider` method `getIcon` to `addItemIcon` (arguments are
+ the same) [BC]
+- [ALL] - Extracted a a method to register a command to an item
+ `Provider.addItemCommand`
+- [ALL] - Providers must expose a public method `getTokenTree` that returns
+ a promise of `ITokenTree` [BC]
+- [ALL] - Providers' `getChildren` should now return only the nodes that
+ are not included in the 'generic' support [BC]
+- [TS/JS] - The symbol for `read-only` and `const` definitions is now `@`
+ (previously `!`)
+- [TS/JS] - Align the TS/JS symbol selection when a node is clicked, to *attempt* to surround only the symbol instead of the whole line (offsets provided by the parser)
+
 ## [0.2.0]
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,18 @@ Contributions of any form are welcome, issue reports, PRs, feedback, etc.
 
 ## Requirements
 
+All new providers MUST implement `IBaseProvider` as responsibly as possible and when the need arises
+to provide a new tree structure, the newly implemented one MUST extend `ITokenTree` in order to be
+compliant as much as possible with it, in order to allow future maintainability. When this is needed
+all 'leaf' types should be based on one of the most types that is the most fitting or at least `IBaseToken`
+to avoid duplication.
+
+It is recommended to use typecasts whenever possible in order for TS to be able to analyse the code properly
+and avoid hidden issues such as magically appearing object properties, etc.
+
 All PRs must be based on and targeting the `develop` branch in order to have
 an always stable branch, following the commonly known git flow in the naming of
-the branches.
-
-It would also be helpful for `bugfix/*` branches to have a corresponding issue
+the branches. It would also be helpful for `bugfix/*` branches to have a corresponding issue
 open that provides information about the problem encountered.
 
 ## Attribution

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vs-treeview",
     "displayName": "File Tree View",
     "description": "Tree View extension providing an overview of the main file symbols",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "author": {
         "name": "Dimitar Dimitrov",
         "email": "daghostman.dd@gmail.com"

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,12 +1,22 @@
 import * as vscode from "vscode";
 import { TreeItem } from "vscode";
-import { IBaseProvider } from "./providers/base";
+import { IBaseProvider, ITokenTree } from "./providers/base";
 import * as token from "./tokens";
 
 export class Provider implements vscode.TreeDataProvider<TreeItem> {
     public static readonly config: vscode.WorkspaceConfiguration;
 
-    public static getIcon(node: vscode.TreeItem, key: string, visibility: string = "public" ) {
+    public static addItemCommand(item: vscode.TreeItem, commandName: string, args?: any[]): vscode.TreeItem {
+        item.command = {
+            arguments: args,
+            command: commandName,
+            title: "",
+        };
+
+        return item;
+    }
+
+    public static addItemIcon(node: vscode.TreeItem, key: string, visibility: string = "public" ) {
         const icons = {
             class: {
                 private: vscode.Uri.file(__dirname + "/../assets/ic_class_private_24px.svg"),
@@ -114,16 +124,186 @@ export class Provider implements vscode.TreeDataProvider<TreeItem> {
 
     public getChildren(element?: TreeItem): Thenable<TreeItem[]> {
         try {
-            const items = this.getProvider().getChildren(element) as Thenable<vscode.TreeItem[]>;
-            items.then((x) => {
-                return x.filter((y) => {
-                    return x.indexOf(y) === x.lastIndexOf(y);
-                });
-            });
+            const provider: IBaseProvider<any> = this.getProvider();
 
-            return items;
+            return provider.getTokenTree().then((tree) => {
+                if (Object.keys(tree).length !== 0) {
+                    const items = this.getBaseChildren(tree, element);
+                    const providerItems = provider.getChildren(element) as Thenable<vscode.TreeItem[]>;
+
+                    return providerItems.then((x) => {
+                        return items.concat(x).filter((y) => {
+                            return items.indexOf(y) === items.lastIndexOf(y);
+                        });
+                    });
+                }
+
+                return provider.getChildren(element);
+            });
         } catch (ex) {
+            vscode.window.showErrorMessage(ex);
             return Promise.resolve([]);
         }
+    }
+
+    private getBaseChildren(tree: ITokenTree, element?: TreeItem): TreeItem[] {
+        const items: TreeItem[] = [];
+        if (element === undefined) {
+            if (tree.strict !== undefined) {
+                items.push(new vscode.TreeItem(
+                    `Strict: ${tree.strict ? "Yes" : "No"}`,
+                ));
+            }
+
+            if (tree.imports !== undefined) {
+                items.push(new vscode.TreeItem(`Imports`, vscode.TreeItemCollapsibleState.Collapsed));
+            }
+
+            if (tree.variables !== undefined) {
+                items.push(new vscode.TreeItem(
+                    `Variables`,
+                    tree.nodes === undefined && tree.functions !== undefined ?
+                        vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+                ));
+            }
+
+            if (tree.functions !== undefined) {
+                items.push(new vscode.TreeItem(
+                    `Functions`,
+                    tree.nodes === undefined && tree.functions !== undefined ?
+                        vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
+                ));
+            }
+
+            if (tree.nodes !== undefined) {
+                for (const cls of tree.nodes) {
+                    const collapsed: number = tree.nodes.indexOf(cls) === 0 ?
+                        vscode.TreeItemCollapsibleState.Expanded :
+                        vscode.TreeItemCollapsibleState.Collapsed;
+
+                    items.push(
+                        Provider.addItemIcon(
+                            new vscode.TreeItem(cls.name, collapsed),
+                            "class",
+                            cls.visibility,
+                        ),
+                    );
+                }
+            }
+        } else {
+            if (tree.imports !== undefined && element.label.toLowerCase() === "imports") {
+                for (const imp of tree.imports) {
+                    const t = new vscode.TreeItem(
+                        `${imp.name}${imp.alias !== undefined ? ` as ${imp.alias}` : ""}`,
+                        vscode.TreeItemCollapsibleState.None,
+                    );
+                    items.push(Provider.addItemCommand(t, "extension.treeview.goto", [ imp.position ]));
+                }
+            }
+
+            if (tree.variables !== undefined && element.label.toLowerCase() === "variables") {
+                for (const variable of tree.variables) {
+                    const t = new vscode.TreeItem(
+                        `${variable.name}` +
+                        `${variable.type !== undefined ? `: ${variable.type}` : ""}` +
+                        `${variable.value !== undefined ? ` = ${variable.value}` : ""}`,
+                        vscode.TreeItemCollapsibleState.None,
+                    );
+
+                    items.push(Provider.addItemCommand(Provider.addItemIcon(
+                        t,
+                        `property_static`,
+                        variable.visibility === undefined ? variable.visibility : "public",
+                    ), "extension.treeview.goto", [variable.position]));
+                }
+            }
+
+            if (tree.functions !== undefined && element.label.toLowerCase() === "functions") {
+                for (const func of tree.functions) {
+                    const args = [];
+                    for (const arg of func.arguments) {
+                        args.push(
+                            `${arg.type !== undefined ? `${arg.type} ` : ""}` +
+                            `${arg.name}${(arg.value !== "" ? ` = ${arg.value}` : "")}`,
+                        );
+                    }
+                    const t = new vscode.TreeItem(
+                        `${func.name}(${args.join(", ")})` +
+                        `${func.type !== undefined ? `: ${func.type}` : ""}`,
+                        vscode.TreeItemCollapsibleState.None,
+                    );
+
+                    items.push(Provider.addItemCommand(Provider.addItemIcon(
+                        t,
+                        `method${func.static ? "_static" : ""}`,
+                        func.visibility,
+                    ), "extension.treeview.goto", [func.position]));
+                }
+            }
+
+            if (tree.nodes !== undefined) {
+                for (const cls of tree.nodes) {
+                    if (cls.name === element.label) {
+                        if (cls.constants) {
+                            for (const constant of cls.constants) {
+                                const t = new vscode.TreeItem(
+                                    `${constant.name} = ${constant.value}`,
+                                    vscode.TreeItemCollapsibleState.None,
+                                );
+                                items.push(Provider.addItemIcon(t, "constant"));
+                            }
+                        }
+
+                        if (cls.properties) {
+                            for (const property of cls.properties) {
+                                const t = new vscode.TreeItem(
+                                    `${property.readonly ? "@" : ""}${property.name}` +
+                                        `${property.value !== "" ? ` = ${property.value}` : ""}`,
+                                    vscode.TreeItemCollapsibleState.None,
+                                );
+
+                                items.push(Provider.addItemCommand(Provider.addItemIcon(
+                                    t,
+                                    `property${property.static ? "_static" : ""}`,
+                                    property.visibility,
+                                ), "extension.treeview.goto", [property.position]));
+                            }
+                        }
+
+                        if (cls.traits) {
+                            for (const trait of cls.traits) {
+                                const t = new vscode.TreeItem(`${trait.name}`, vscode.TreeItemCollapsibleState.None);
+                                items.push(Provider.addItemIcon(t, "trait"));
+                            }
+                        }
+
+                        if (cls.methods) {
+                            for (const method of cls.methods) {
+                                const args = [];
+                                for (const arg of method.arguments) {
+                                    args.push(
+                                        `${arg.type !== undefined ? `${arg.type} ` : ""}${arg.name}` +
+                                            `${(arg.value !== "" ? ` = ${arg.value}` : "")}`,
+                                    );
+                                }
+                                const t = new vscode.TreeItem(
+                                    `${method.name}(${args.join(", ")})` +
+                                        `${method.type !== undefined ? `: ${method.type}` : ""}`,
+                                    vscode.TreeItemCollapsibleState.None,
+                                );
+
+                                items.push(Provider.addItemCommand(Provider.addItemIcon(
+                                    t,
+                                    `method${method.static ? "_static" : ""}`,
+                                    method.visibility,
+                                ), "extension.treeview.goto", [method.position]));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return items;
     }
 }

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -5,4 +5,6 @@ export * from "../tokens";
 export interface IBaseProvider<T> extends vscode.TreeDataProvider<T> {
     hasSupport(langId: string): boolean;
     refresh(event?: vscode.TextDocumentChangeEvent): void;
+
+    getTokenTree(): Thenable<token.ITokenTree>;
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -47,4 +47,5 @@ export interface ITokenTree {
     imports?: ImportToken[];
     nodes?: IEntityToken[];
     functions?: IMethodToken[];
+    variables?: IVariableToken[];
 }


### PR DESCRIPTION
* Provide a helper method for adding a command to a leaf

* add method to provider the ITokenTree of the current file

* Implement `getTokenTree` and minor improvements to handling

* Revamp of providers: duplication-- and maintainability++

* Add support for global variables

* Align TS/JS selection to match the behaviour of PHP and JSON (select only the symbol)

* updated contribution guides

* show unhandled exceptions as VSCode errors