### PR TITLE
Make available providers configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
 _[BC]_ Stands for *B*reaking *C*hange
+## [Unreleased]
+
+### Added
+
+- [ALL] - Make providers loadable on-demand through `treeview.allowedProviders`
+
 ## [1.0.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -38,7 +38,25 @@
                     "name": "Tree"
                 }
             ]
-        }
+        },
+        "configuration":[
+            {
+                "type": "object",
+                "title": "File Tree View root config",
+                "properties": {
+                    "treeview.allowedProviders": {
+                        "type": "array",
+                        "default": [
+                            "javascript",
+                            "json",
+                            "openhab",
+                            "php"
+                        ],
+                        "description": "List of provider identifiers that are allowed for the workspace or in general"
+                    }
+                }
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,12 +16,31 @@ function goToDefinition(range: vscode.Range) {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-    const provider = new Provider([
-        new PhpProvider(),
-        new TypescriptProvider(),
-        new JsonProvider(),
-        new RuleProvider(),
-    ] as Array<IBaseProvider<any>>);
+    const providers: Array<IBaseProvider<string | vscode.TreeItem>> = [];
+    const config = vscode.workspace.getConfiguration("treeview");
+
+    const allowedProviders: string[] = config.has("allowedProviders") ?
+        config.get("allowedProviders") : [];
+
+    if (allowedProviders.length === 0 || allowedProviders.indexOf("php") !== -1) {
+        providers.push(new PhpProvider());
+    }
+
+    if (allowedProviders.length === 0 ||
+        allowedProviders.indexOf("typescript") !== -1 ||
+        allowedProviders.indexOf("javascript") !== -1) {
+        providers.push(new TypescriptProvider());
+    }
+
+    if (allowedProviders.length === 0 || allowedProviders.indexOf("json") !== -1) {
+        providers.push(new JsonProvider());
+    }
+
+    if (allowedProviders.length === 0 || allowedProviders.indexOf("openhab") !== -1) {
+        providers.push(new RuleProvider());
+    }
+
+    const provider = new Provider(providers as Array<IBaseProvider<any>>);
 
     vscode.window.registerTreeDataProvider("tree-outline", provider);
     vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => goToDefinition(range));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,9 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
         providers.push(new PhpProvider());
     }
 
-    if (allowedProviders.length === 0 ||
-        allowedProviders.indexOf("typescript") !== -1 ||
-        allowedProviders.indexOf("javascript") !== -1) {
+    if (allowedProviders.length === 0 || allowedProviders.indexOf("javascript") !== -1) {
         providers.push(new TypescriptProvider());
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
         providers.push(new RuleProvider());
     }
 
-    const provider = new Provider(providers as Array<IBaseProvider<any>>);
+    const provider = new Provider(providers as Array<IBaseProvider<string | vscode.TreeItem>>);
 
     vscode.window.registerTreeDataProvider("tree-outline", provider);
     vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => goToDefinition(range));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,8 @@
 "use strict";
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
+
 import * as vscode from "vscode";
 import { Provider } from "./provider";
-import { JsonProvider, PhpProvider, TypescriptProvider } from "./providers";
-import { IBaseProvider } from "./providers/base";
-import { RuleProvider } from "./providers/openhab/rule";
+import { IBaseProvider, JsonProvider, PhpProvider, RuleProvider, TypescriptProvider } from "./providers";
 
 function goToDefinition(range: vscode.Range) {
     const editor: vscode.TextEditor = vscode.window.activeTextEditor;
@@ -17,8 +14,7 @@ function goToDefinition(range: vscode.Range) {
         // Swap the focus to the editor
         vscode.window.showTextDocument(editor.document, editor.viewColumn, false);
 }
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+
 export function activate(context: vscode.ExtensionContext) {
     const provider = new Provider([
         new PhpProvider(),
@@ -29,23 +25,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.window.registerTreeDataProvider("tree-outline", provider);
     vscode.commands.registerCommand("extension.treeview.goto", (range: vscode.Range) => goToDefinition(range));
-    // Use the console to output diagnostic information (console.log) and errors (console.error)
-    // This line of code will only be executed once when your extension is activated
-
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with  registerCommand
-    // The commandId parameter must match the command field in package.json
-    // let disposable = vscode.commands.registerCommand('extension.sayHello', () => {
-    //     // The code you place here will be executed every time your command is executed
-
-    //     // Display a message box to the user
-    //     vscode.window.showInformationMessage('Hello World!');
-    // });
-
-    // context.subscriptions.push(disposable);
 }
 
-// this method is called when your extension is deactivated
 export function deactivate() {
     return undefined;
 }

--- a/src/providers/php.ts
+++ b/src/providers/php.ts
@@ -70,7 +70,7 @@ export class PhpProvider implements IBaseProvider<vscode.TreeItem> {
                     const methods = node.body.filter((x) => x.kind === "method");
                     const traits = node.body.filter((x) => x.kind === "traituse");
 
-                    entity.name = (tree.namespace||'')+`\\${node.name}`;
+                    entity.name = (tree.namespace || "") + `\\${node.name}`;
                     entity.traits = traits.length === 0 ? undefined : this.handleUseTraits(traits);
                     entity.constants = constants.length === 0 ? undefined : this.handleConstants(constants);
                     entity.properties = properties.length === 0 ? undefined : this.handleProperties(properties);


### PR DESCRIPTION
Make provider registration configurable in order to avoid the overhead of loading all available providers, when only some are used. It might make up for cases where the provider initializes external libraries (as they are) which increase the memory footprint.