### PR TITLE
Introduce some minor configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ _[BC]_ Stands for *B*reaking *C*hange
 ### Added
 
 - [ALL] - Make providers loadable on-demand through `treeview.allowedProviders`
+- [PHP] - Make namespace presentation configurable
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ _[BC]_ Stands for *B*reaking *C*hange
 
 - [ALL] - Make providers loadable on-demand through `treeview.allowedProviders`
 - [PHP] - Make namespace presentation configurable
+- [TS/JS] - `readonly` identifier character is now configurable
 
 ### Changes
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,25 @@
                             "php"
                         ],
                         "description": "List of provider identifiers that are allowed for the workspace or in general"
+                    },
+                    "treeview.php": {
+                        "type":"object",
+                        "description": "Section for PHP support related configurations",
+                        "properties": {
+                            "namespacePosition": {
+                                "type":"string",
+                                "enum": [
+                                    "suffix",
+                                    "none",
+                                    "fqn"
+                                ],
+                                "default": "suffix",
+                                "description": "Control the position where the current namespace is shown"
+                            }
+                        },
+                        "default": {
+                            "namespacePosition": "suffix"
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,20 @@
                         "default": {
                             "namespacePosition": "suffix"
                         }
+                    },
+                    "treeview.js": {
+                        "type":"object",
+                        "description": "Section for JS/TS support related configurations",
+                        "properties": {
+                            "readonlyCharacter": {
+                                "type":"string",
+                                "default": "@",
+                                "description": "Character with which to prefix `readonly` properties"
+                            }
+                        },
+                        "default": {
+                            "readonlyCharacter": "@"
+                        }
                     }
                 }
             }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -261,7 +261,7 @@ export class Provider implements vscode.TreeDataProvider<TreeItem> {
                         if (cls.properties) {
                             for (const property of cls.properties.sort(Provider.sort)) {
                                 const t = new vscode.TreeItem(
-                                    `${property.readonly ? "@" : ""}${property.name}: ${property.type}` +
+                                    `${property.name}: ${property.type}` +
                                         `${property.value !== "" ? ` = ${property.value}` : ""}`,
                                     vscode.TreeItemCollapsibleState.None,
                                 );

--- a/src/providers/typescript.ts
+++ b/src/providers/typescript.ts
@@ -5,6 +5,7 @@ import * as token from "./../tokens";
 import { IBaseProvider } from "./base";
 
 export class TypescriptProvider implements IBaseProvider<vscode.TreeItem> {
+    private config: vscode.WorkspaceConfiguration;
     private parser: ts.TypescriptParser;
     private tree: token.ITokenTree = {} as token.ITokenTree;
 
@@ -14,6 +15,12 @@ export class TypescriptProvider implements IBaseProvider<vscode.TreeItem> {
 
     public constructor() {
         this.parser = new ts.TypescriptParser();
+        this.config = vscode.workspace.getConfiguration("treeview.js");
+    }
+
+    get roChar(): string {
+        return this.config.has("readonlyCharacter") ?
+        this.config.get("readonlyCharacter") : "@";
     }
 
     public hasSupport(langId: string): boolean {
@@ -22,6 +29,7 @@ export class TypescriptProvider implements IBaseProvider<vscode.TreeItem> {
     }
 
     public refresh(event?: vscode.TextDocumentChangeEvent): void {
+        this.config = vscode.workspace.getConfiguration("treeview.js");
         // console.log("TypeScript/JavaScript Tree View provider refresh triggered")
     }
 
@@ -60,7 +68,7 @@ export class TypescriptProvider implements IBaseProvider<vscode.TreeItem> {
                     }
 
                     tree.variables.push({
-                        name: `${dec.isConst ? "@" : ""}${dec.name}`,
+                        name: `${dec.isConst ? this.roChar : ""}${dec.name}`,
                         position: this.generateRangeForSelection(dec.name, dec.start),
                         type: dec.type === undefined ? "any" : dec.type,
                         visibility: dec.isExported === true ? "public" : "protected",
@@ -142,7 +150,7 @@ export class TypescriptProvider implements IBaseProvider<vscode.TreeItem> {
             )).split(" ").slice(0, 5);
 
             properties.push({
-                name: property.name,
+                name: (def.indexOf("readonly") > -1 ? this.roChar : "") + property.name,
                 position: this.generateRangeForSelection(property.name, property.start),
                 readonly: (def.indexOf("readonly") > -1),
                 static: (def.indexOf("static") > -1),


### PR DESCRIPTION
- PHP namespace position can be personalized by using the new `treeview.php` configuration. Valid values are: 
   - `fqn` - prefixes the class name with the full namespaces
   - `suffix` - adds the namespace after the class name (default)
   - `none` - removes the namespace from the tree
 - TS/JS the `readonly` identifier is now configurable (default to `@`) through `treeview.js`. Note this config section affects both TypeScript and JavaScript behaviour