### PR TITLE
openHAB Items files support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { Provider } from "./provider";
 import {
     IBaseProvider,
+    ItemsProvider,
     JavaProvider,
     JsonProvider,
     PhpProvider,
@@ -48,6 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (allowedProviders.length === 0 || allowedProviders.indexOf("openhab") !== -1) {
         providers.push(new RuleProvider());
+        providers.push(new ItemsProvider());
     }
 
     if (allowedProviders.length === 0 || allowedProviders.indexOf("python") !== -1) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ export { JsonProvider } from "./json";
 export { PhpProvider } from "./php";
 export { TypescriptProvider } from "./typescript";
 export { RuleProvider } from "./openhab/rule";
+export { ItemsProvider } from "./openhab/items";
 export { IBaseProvider } from "./base";
 export { PythonProvider } from "./python";
 export { JavaProvider } from "./java";

--- a/src/providers/openhab/items.ts
+++ b/src/providers/openhab/items.ts
@@ -7,20 +7,20 @@ import {
     TraitItem,
 } from "./../../tokens";
 import { IBaseProvider } from "./../base";
-import { IRuleTree, RuleParser } from "./ruleParser";
+import { IItemsTree, ItemsParser } from "./itemsParser";
 
-export class RuleProvider implements IBaseProvider<vscode.TreeItem> {
+export class ItemsProvider implements IBaseProvider<vscode.TreeItem> {
     private tree: Thenable<ITokenTree>;
-    private parser: RuleParser;
+    private parser: ItemsParser;
     private text: string;
     private editor: vscode.TextEditor;
 
     public constructor() {
-        this.parser = new RuleParser();
+        this.parser = new ItemsParser();
     }
     public hasSupport(langId: string) {
         return langId.toLowerCase() === "openhab" &&
-            vscode.window.activeTextEditor.document.fileName.endsWith("rules");
+            vscode.window.activeTextEditor.document.fileName.endsWith("items");
     }
 
     public refresh(document: vscode.TextDocument): void {
@@ -29,7 +29,7 @@ export class RuleProvider implements IBaseProvider<vscode.TreeItem> {
         });
     }
 
-    public getTokenTree(): Thenable<IRuleTree> {
+    public getTokenTree(): Thenable<IItemsTree> {
         return this.tree;
     }
 
@@ -46,26 +46,26 @@ export class RuleProvider implements IBaseProvider<vscode.TreeItem> {
 
         return this.getTokenTree().then((tree) => {
             if (element === undefined) {
-                if (tree.rules && tree.rules.length) {
+                if (tree.items && tree.items.length) {
                     items.push(new SectionItem(
-                        `Rules`,
-                        tree.rules !== undefined ?
+                        `Items`,
+                        tree.items !== undefined ?
                             vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.Collapsed,
-                        "rule-section",
+                        "items-section",
                     ));
                 }
             } else {
-                if (element.contextValue === "rule-section") {
-                    for (const rule of tree.rules) {
+                if (element.contextValue === "items-section") {
+                    for (const item of tree.items) {
                         const t = new TraitItem(
-                            `${rule.name}`,
+                            `${item.name}`,
                             vscode.TreeItemCollapsibleState.None,
                         );
 
                         items.push(Provider.addItemCommand(Provider.addItemIcon(
                             t,
                             `use`,
-                        ), "extension.treeview.goto", [rule.position]));
+                        ), "extension.treeview.goto", [item.position]));
                     }
                 }
             }

--- a/src/providers/openhab/itemsParser.ts
+++ b/src/providers/openhab/itemsParser.ts
@@ -1,0 +1,59 @@
+import * as vscode from "vscode";
+import { IInterfaceToken as InterfaceToken, ImportToken, ITokenTree, IVariableToken } from "../../tokens";
+
+export class ItemsParser {
+    private text: string;
+
+    public parseSource(text: string): Thenable<ITokenTree> {
+        this.text = text;
+        // Remove comments
+        text = text.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "$1");
+        const lines = text.split("\n");
+
+        const types = [
+            "Color",
+            "Contact",
+            "DateTime",
+            "Dimmer",
+            "Group",
+            "Image",
+            "Location",
+            "Number",
+            "Player",
+            "Rollershutter",
+            "String",
+            "Switch",
+        ];
+
+        const items = lines
+            .filter((line) => {
+                const arr = line.split(/\s+/);
+                return types.includes(arr[0]);
+            })
+            .map((line) => {
+                const arr = line.split(/\s+/);
+                return {
+                    name: arr[1],
+                    position: this.getPosition(arr[1]),
+                } as IVariableToken;
+            }) || [];
+
+        return Promise.resolve({ items } as IItemsTree);
+    }
+
+    public getPosition(text: string): vscode.Range {
+        const query = (q) => q.includes(text);
+        const lines = this.text.split("\n");
+        const line = lines.find(query);
+        const lineIndex = lines.findIndex(query);
+
+        return new vscode.Range(
+            new vscode.Position(lineIndex, line.indexOf(text)),
+            new vscode.Position(lineIndex, line.indexOf(text) + text.length),
+        );
+    }
+}
+
+export interface IItemsTree extends ITokenTree {
+    items?: IVariableToken[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es7"
         ],
         "sourceMap": true,
         "rootDir": "src"


### PR DESCRIPTION
Along with the *.rules file we can now work on the *.items files:

![items](https://user-images.githubusercontent.com/2270505/35987226-6c1b4294-0cfb-11e8-90bd-3ac63f647d51.gif)

I wanted to have the list sorted (by the `name field`) as well, but couldn't wrap my head around it now :)
Cheers!