### PR TITLE
Show notification instead of opening file

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -279,32 +279,40 @@ export class Provider implements vscode.TreeDataProvider<TreeItem> {
                     );
 
                     fs.open(location.fsPath, "wx", (err, fd) => {
-                        if (err === null) {
-                            fs.closeSync(fd);
-
-                            const workspaceEdits: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
-                            workspaceEdits.set(location, provider.generate(
-                                entityName,
-                                node,
-                                includeBody,
-                                {
-                                    ext: path.extname(documentName),
-                                    ns,
-                                    strict,
-                                },
-                            ));
-
-                            vscode.workspace.applyEdit(workspaceEdits);
-                            vscode.workspace.openTextDocument(location)
-                                .then((document) =>
-                                    vscode.window.showTextDocument(document, vscode.ViewColumn.Active, true));
+                        if (err !== null) {
+                            vscode.window.showErrorMessage(
+                                `File "${location.fsPath}" already exists. ${err.message}`,
+                            );
 
                             return void 0;
                         }
+                        fs.closeSync(fd);
 
-                        vscode.window.showErrorMessage(
-                            `File "${vscode.workspace.asRelativePath(location, false)}" already exists.`,
-                        );
+                        const workspaceEdits: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+                        workspaceEdits.set(location, provider.generate(
+                            entityName,
+                            node,
+                            includeBody,
+                            {
+                                ext: path.extname(documentName),
+                                ns,
+                                strict,
+                            },
+                        ));
+
+                        vscode.workspace.applyEdit(workspaceEdits);
+                        vscode.workspace.openTextDocument(location)
+                            .then((document) => {
+                                document.save().then((saved) => {
+                                    const loc = location.fsPath.substr(cwd.length).replace(/\\/, "/");
+                                    if (saved) {
+                                        vscode.window.showInformationMessage(`Successfully created "${loc}"`);
+                                    } else {
+                                        vscode.window.showErrorMessage(`Unable to save "${loc}".`);
+                                    }
+
+                                });
+                            });
                     });
                 });
 


### PR DESCRIPTION
This fixes the annoying issue which opens the file as an external file instead of as part of the current workspace. This is mainly annoying and since there do not appear to be any particular reason to open an extracted interface and that in some cases 'Content on disk is newer' can occur it is better to just show a notification with the relative file path.